### PR TITLE
Redir to Comsys Website fix

### DIFF
--- a/src/templates/syscom/Main.tsx
+++ b/src/templates/syscom/Main.tsx
@@ -96,7 +96,7 @@ const Main = (props: IMainProps) => {
 
         <div className="border-t border-gray-300 py-8 text-center text-sm">
           © Copyright {new Date().getFullYear()}{" "}
-          <a href="comsys.rwth-aachen.de">ComSys-Lehrstuhl</a>. Dies ist
+          <a href="https://www.comsys.rwth-aachen.de">ComSys-Lehrstuhl</a>. Dies ist
           (leider) nicht die echte ComSys-Lehrstuhl Webseite.
         </div>
       </div>


### PR DESCRIPTION
Before it would redirect to 404 as it looks into own Namespace, now the redirect to Comsys should work